### PR TITLE
Update Opal to 0.6.x

### DIFF
--- a/opal-sprockets.gemspec
+++ b/opal-sprockets.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths  = ['lib']
 
   s.add_dependency 'sprockets'
-  s.add_dependency 'opal', '~> 0.5.0'
+  s.add_dependency 'opal', '~> 0.6.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
The latest opal-sprockets(0.3.0) requires Opal 0.5.x, but it seems work fine with Opal 0.6.2. 
