### PR TITLE
Avoid OpalLoaded undefined when applications have no dependencies.

### DIFF
--- a/lib/opal/sprockets.rb
+++ b/lib/opal/sprockets.rb
@@ -32,7 +32,7 @@ module Opal
       names = names.map { |name| name.sub(/(\.(js|rb|opal))*\z/, '') }
       stubbed = ::Opal::Config.stubbed_files.to_a
 
-      loaded = 'OpalLoaded || []'
+      loaded = 'typeof(OpalLoaded) === "undefined" ? [] : OpalLoaded'
       loaded = "#{stubbed.to_json}.concat(#{loaded})" if stubbed.any?
 
       [

--- a/spec/sprockets_spec.rb
+++ b/spec/sprockets_spec.rb
@@ -15,7 +15,7 @@ describe Opal::Sprockets do
       allow(Opal::Config).to receive(:stubbed_files) { %w[foo bar] }
 
       code = described_class.load_asset('baz')
-      expect(code).to include('Opal.loaded(["foo","bar"].concat(OpalLoaded || []));')
+      expect(code).to include(%{Opal.loaded(["foo","bar"].concat(typeof(OpalLoaded) === "undefined" ? [] : OpalLoaded));})
       expect(code).to include('Opal.require("baz");')
     end
 
@@ -42,7 +42,7 @@ describe Opal::Sprockets do
     it 'detects deprecated env with multiple names' do
       code = described_class.load_asset('foo', 'bar', env)
       expect(code).to eq([
-        'Opal.loaded(OpalLoaded || []);',
+        'Opal.loaded(typeof(OpalLoaded) === "undefined" ? [] : OpalLoaded);',
         'Opal.require("foo");',
         'Opal.require("bar");',
       ].join("\n"))


### PR DESCRIPTION
I've structured my web app to pre-build opal as well as all external JS requires so reloading the application is fast for development. I then require this bundled JS file manually in my HTML. The main application has no external requires so Opal::Sprockets.loaded_asset is never called, causing the error '(index):1 Uncaught ReferenceError: OpalLoaded is not defined'

The issue can be worked around by adding a small dependency to my main application or by adding a polyfill like ' if (typeof OpalLoaded === 'undefined') = [].

I've made this PR to fix this edge case.