### PR TITLE
Fix an off-by-one error for source maps

### DIFF
--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -146,7 +146,7 @@ class Opal::Sprockets::Processor
       if input[:filename] =~ opal_extnames_regexp
         input[:data]
       else
-        "#{input[:data]}\n#{Opal::Sprockets.loaded_asset(input[:name])}"
+        "#{input[:data]};#{Opal::Sprockets.loaded_asset(input[:name])}"
       end
     end
   end


### PR DESCRIPTION
Post-processor ran without concerning about source maps. Let's make it so that at least line count isn't changed.