### PR TITLE
Fix issue with upgrading gems breaking Opal compilation in Rails applications due to incorrect Sprockets caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.0.4](https://github.com/opal/opal-sprockets/compare/v1.0.3...v1.0.4)
+
+*3 August 2024*
+
+- Fix issue with upgrading gems breaking Opal compilation in Rails applications due to incorrect Sprockets caching
+
+## [1.0.3](https://github.com/opal/opal-sprockets/compare/v1.0.2...v1.0.3)
+
+*24 December 2024*
+
+- Supporting Ruby 3.1
+
 ## [1.0.2](https://github.com/opal/opal-sprockets/compare/v1.0.1...v1.0.2)
 
 *24 August 2021*

--- a/lib/opal/sprockets/processor.rb
+++ b/lib/opal/sprockets/processor.rb
@@ -11,7 +11,8 @@ require 'opal/sprockets'
 class Opal::Sprockets::Processor
   @@cache_key = nil
   def self.cache_key
-    @@cache_key ||= ['Opal', Opal::VERSION, Opal::Config.config].to_json.freeze
+    gem_config = Gem.loaded_specs.map {|gem_key, gem_spec| [gem_spec.name, gem_spec.version.to_s] }
+    @@cache_key ||= ['Opal', Opal::VERSION, Opal::Config.config, gem_config].to_json.freeze
   end
 
   def self.reset_cache_key!

--- a/lib/opal/sprockets/version.rb
+++ b/lib/opal/sprockets/version.rb
@@ -1,5 +1,5 @@
 module Opal
   module Sprockets
-    VERSION = '1.0.3'
+    VERSION = '1.0.4'
   end
 end

--- a/opal-sprockets.gemspec
+++ b/opal-sprockets.gemspec
@@ -3,7 +3,7 @@ require_relative 'lib/opal/sprockets/version'
 Gem::Specification.new do |spec|
   spec.name         = 'opal-sprockets'
   spec.version      = Opal::Sprockets::VERSION
-  spec.authors      = ['Elia Schito', 'Adam Beynon']
+  spec.authors      = ['Elia Schito', 'Adam Beynon', 'Andy Maleh']
   spec.email        = 'elia@schito.me'
 
   spec.summary      = 'Sprockets support for Opal.'


### PR DESCRIPTION
Fix issue with upgrading gems breaking Opal compilation in Rails applications due to incorrect Sprockets caching (more details are included below).

In the past, I was forced to run `rm -rf tmp/catche` after every upgrade of gems that were using Opal.

Now, with this fix, the problem goes away without having to do that anymore.

This was an issue mentioned in Opal Slack as:

> I ran into a generally consistent issue when using Opal in a Rails app. If I update my Rails app gem dependencies (like the glimmer-dsl-web gem that depends on Opal or some other gems) and I restart the server, when I access the webpage that uses Opal, it gives me weird errors (they are untraceable to my code). I discovered that the consistent fix for the issue is to always run rm -rf tmp/cache after updating any gems in the Rails app, and then to restart the server afterwards.
I don't run into the issue anymore if I do run rm -rf tmp/cache after updating any gems. Of course, the downside to this is I lose caching, so the next request takes a little longer than normal. Also, it requires a manual step from me after updating any gems.
This seems to be caused by the way Opal caches data in the Rails server. It must have a bug that breaks it if the Ruby gems change (like changing versions or perhaps changing gem paths given that gems have the version number in their path name).
I just wanted to note it in case you are not aware of this issue so that you would fix it.